### PR TITLE
Update tests, movement and change event.

### DIFF
--- a/tests/movementX_Y_basic-manual.html
+++ b/tests/movementX_Y_basic-manual.html
@@ -11,10 +11,6 @@
         color: green;
         color: green;
     }
-
-    .data-log span {
-        color: blue;
-    }
 </style>
 </head>
 <body>
@@ -28,8 +24,7 @@
             <li>Make sure the window is not maximized.</li>
             <li>Click to start logging mouse data.</li>
             <li>Move the mouse within the window.</li>
-            <li>Click again to end the log.</li>
-            <li>Click to start logging mouse data.</li>
+            <li>Click again to end Test1 and start Test2.</li>
             <li>Move the mouse outside the window.</li>
             <li>Click again to end the log.</li>
         </ol>
@@ -38,11 +33,14 @@
 
     <div id="status-log">Waiting... Click to start loging.</div>
     <div class="data-log">
-        <p>clientX_init: <span id="clientX_init-log">NaN</span>, clientY_init: <span id="clientY_init-log">NaN</span></p>
-        <p>clientX_last: <span id="clientX_last-log">NaN</span>, clientY_last: <span id="clientY_last-log">NaN</span></p>
-        <p>clientX_delta: <span id="clientX_delta-log">NaN</span>, clientY_delta: <span id="clientY_delta-log">NaN</span></p>
-        <p>movementX: <span id="movementX-log">NaN</span>, movementY: <span id="movementY-log">NaN</span></p>
-        <p>movementX_sum: <span id="movementX_sum-log">NaN</span>, movementY_sum: <span id="movementY_sum-log">NaN</span></p>
+	    <table>
+	    	<tr><td></td><td>X</td><td>Y</td></tr>
+	    	<tr><td>client_init:</td><td id="clientX_init-log">X</td><td id="clientY_init-log">Y</td></tr>
+	    	<tr><td>client_last:</td><td id="clientX_last-log">X</td><td id="clientY_last-log">Y</td></tr>
+	    	<tr><td>client_delta:</td><td id="clientX_delta-log">X</td><td id="clientY_delta-log">Y</td></tr>
+	    	<tr><td>movement_sum:</td><td id="movementX_sum-log">X</td><td id="movementY_sum-log">Y</td></tr>
+	    	<tr><td>movement:</td><td id="movementX-log">X</td><td id="movementY-log">Y</td></tr>
+	    </table>
     </div>
     <hr/>
 
@@ -85,13 +83,12 @@
                         assert_approx_equals(movementY_sum, clientY_last - clientY_init, 10, "sum of movementY = clientY_init - clientY_last");
                     });
                     movementX_Y_inside_window_Test.done();
-                break;
-                case 3:
+
                     status_log.innerHTML = "outside window: logging...";
                     clientX_init = null;
                     clientY_init = null;
                 break;
-                case 4:
+                case 3:
                     status_log.innerHTML = "outside window: done";
 
                     // differ from the approximate calculation in the previous case

--- a/tests/movementX_Y_basic-manual.html
+++ b/tests/movementX_Y_basic-manual.html
@@ -15,18 +15,18 @@
 </head>
 <body>
     <h2>Description</h2>
-    <p>This test if movementX/Y can provide the change in position of the pointer (approximately), as if movementX/Y = eNow.screenX/Y-ePrevious.screenX/Y (+/- 10), with the exception of when screenX can not be updated because the pointer is clipped by the user agent screen boundaries.</p>
+    <p>This test if movementX/Y can provide the change in position of the pointer, as if movementX/Y = eNow.screenX/Y-ePrevious.screenX/Y, with the exception of when screenX can not be updated because the pointer is clipped by the user agent screen boundaries.</p>
     <hr/>
 
     <h2>Manual Test Steps:</h2>
     <p>
         <ol>
             <li>Make sure the window is not maximized.</li>
-            <li>Click to start logging mouse data.</li>
-            <li>Move the mouse within the window.</li>
+            <li>Click to start Test1.</li>
+            <li>Move the mouse within the window, slow and fast, like a scribble.</li>
             <li>Click again to end Test1 and start Test2.</li>
-            <li>Move the mouse outside the window.</li>
-            <li>Click again to end the log.</li>
+            <li>Move the mouse outside the window, and then re-enter the window at a different location at least 100 pixels away.</li>
+            <li>Click again to end tests.</li>
         </ol>
     </p>
     <hr/>
@@ -64,7 +64,7 @@
         var clientX_init, clientY_init, movementX, movementY, movementX_sum, movementY_sum, clientX_last, clientY_last;
 
         var movementX_Y_inside_window_Test = async_test("Test that movementX/Y = eNow.screenX/Y-ePrevious.screenX/Y.");
-        var movementX_Y_outside_window_Test = async_test("Test that movementX/Y not equals to eNow.screenX/Y-ePrevious.screenX/Y when the pointer is clipped by the screen boundary.");
+        var movementX_Y_outside_window_Test = async_test("Test that movementX/Y not equals to eNow.screenX/Y-ePrevious.screenX/Y when the pointer moves outside the window.");
 
         document.addEventListener("click", function (e) {
             click_counter++;
@@ -79,8 +79,8 @@
                     // approximately(+/- 10)
                     // a little drift should be tollerated
                     movementX_Y_inside_window_Test.step(function() {
-                        assert_approx_equals(movementX_sum, clientX_last - clientX_init, 10, "sum of movementX = clientX_init - clientX_last");
-                        assert_approx_equals(movementY_sum, clientY_last - clientY_init, 10, "sum of movementY = clientY_init - clientY_last");
+                        assert_equals(movementX_sum, clientX_last - clientX_init, "sum of movementX = clientX_init - clientX_last");
+                        assert_equals(movementY_sum, clientY_last - clientY_init, "sum of movementY = clientY_init - clientY_last");
                     });
                     movementX_Y_inside_window_Test.done();
 
@@ -92,8 +92,8 @@
                     status_log.innerHTML = "outside window: done";
 
                     // differ from the approximate calculation in the previous case
-                    assert_greater_than(Math.abs(movementX_sum - clientX_last + clientX_init), 10, "movementX can't provide the change in position of the pointer when the pointer crosses window boundary");
-                    assert_greater_than(Math.abs(movementY_sum - clientY_last + clientY_init), 10, "movementY can't provide the change in position of the pointer when the pointer crosses window boundary");
+                    assert_greater_than(Math.abs(movementX_sum - clientX_last + clientX_init), 100, "movementX can't provide the change in position of the pointer when the pointer crosses window boundary");
+                    assert_greater_than(Math.abs(movementY_sum - clientY_last + clientY_init), 100, "movementY can't provide the change in position of the pointer when the pointer crosses window boundary");
                     movementX_Y_outside_window_Test.done();
                 break;
             }

--- a/tests/movementX_Y_basic-manual.html
+++ b/tests/movementX_Y_basic-manual.html
@@ -38,9 +38,11 @@
 
     <div id="status-log">Waiting... Click to start loging.</div>
     <div class="data-log">
-        <p>movementX: <span id="movementX-log">NaN</span>, movementX_sum: <span id="movementX_sum-log">NaN</span>, movementY: <span id="movementY-log">NaN</span>, movementY_sum: <span id="movementY_sum-log">NaN</span></p>
         <p>clientX_init: <span id="clientX_init-log">NaN</span>, clientY_init: <span id="clientY_init-log">NaN</span></p>
         <p>clientX_last: <span id="clientX_last-log">NaN</span>, clientY_last: <span id="clientY_last-log">NaN</span></p>
+        <p>clientX_delta: <span id="clientX_delta-log">NaN</span>, clientY_delta: <span id="clientY_delta-log">NaN</span></p>
+        <p>movementX: <span id="movementX-log">NaN</span>, movementY: <span id="movementY-log">NaN</span></p>
+        <p>movementX_sum: <span id="movementX_sum-log">NaN</span>, movementY_sum: <span id="movementY_sum-log">NaN</span></p>
     </div>
     <hr/>
 
@@ -56,6 +58,8 @@
             clientY_init_log = document.querySelector('#clientY_init-log'),
             clientX_last_log = document.querySelector('#clientX_last-log'),
             clientY_last_log = document.querySelector('#clientY_last-log');
+            clientX_delta_log = document.querySelector('#clientX_delta-log'),
+            clientY_delta_log = document.querySelector('#clientY_delta-log');
 
         var click_counter = 0;
 
@@ -115,20 +119,24 @@
 
                 clientX_last = e.clientX;
                 clientY_last = e.clientY;
+                clientX_delta = clientX_last - clientX_init;
+                clientY_delta = clientY_last - clientY_init;
 
                 updateData();
             }
         });
 
         function updateData() {
-            movementX_log.innerHTML = movementX;
-            movementY_log.innerHTML = movementY;
-            movementX_sum_log.innerHTML = movementX_sum;
-            movementY_sum_log.innerHTML = movementY_sum;
             clientX_init_log.innerHTML = clientX_init;
             clientY_init_log.innerHTML = clientY_init;
             clientX_last_log.innerHTML = clientX_last;
             clientY_last_log.innerHTML = clientY_last;
+            clientX_delta_log.innerHTML = clientX_delta;
+            clientY_delta_log.innerHTML = clientY_delta;
+            movementX_log.innerHTML = movementX;
+            movementY_log.innerHTML = movementY;
+            movementX_sum_log.innerHTML = movementX_sum;
+            movementY_sum_log.innerHTML = movementY_sum;
         }
         </script>
     </body>

--- a/tests/movementX_Y_no-jumps-manual.html
+++ b/tests/movementX_Y_no-jumps-manual.html
@@ -15,15 +15,18 @@
 </head>
 <body>
     <h2>Description</h2>
-    <p>This test if movementX/Y can provide the change in position of the pointer, as if movementX/Y = eNow.screenX/Y-ePrevious.screenX/Y</p>
+    <p>This test that movementX/Y do not jump by a large value when exiting and re-entering the window.</p>
     <hr/>
 
     <h2>Manual Test Steps:</h2>
     <p>
         <ol>
-            <li>Click to start Test1.</li>
-            <li>Move the mouse within the window, slow and fast, like a scribble.</li>
-            <li>Click again to end test.</li>
+            <li>Make sure the window is not maximized.</li>
+            <li>Click to start Test.</li>
+            <li>Move the mouse slowly out of the window.
+            <li>Move as fast as needed to a different location outside the window at least 100 pixels away</li>
+            <li>Slowly re-enter the window.</li>
+            <li>Click again to end tests.</li>
         </ol>
     </p>
     <hr/>
@@ -60,25 +63,25 @@
 
         var clientX_init, clientY_init, movementX, movementY, movementX_sum, movementY_sum, clientX_last, clientY_last;
 
-        var movementX_Y_inside_window_Test = async_test("Test that movementX/Y = eNow.screenX/Y-ePrevious.screenX/Y.");
+        var movementX_Y_outside_window_Test = async_test("Test that movementX/Y do not have large values when re-entering from outside the window.");
 
         document.addEventListener("click", function (e) {
             click_counter++;
 
             switch(click_counter) {
                 case 1:
-                    status_log.innerHTML = "inside window: logging...";
+                    status_log.innerHTML = "logging...";
                 break;
                 case 2:
-                    status_log.innerHTML = "inside window: done";
+                    status_log.innerHTML = "done";
 
                     // approximately(+/- 10)
                     // a little drift should be tollerated
-                    movementX_Y_inside_window_Test.step(function() {
+                    movementX_Y_outside_window_Test.step(function() {
                         assert_equals(movementX_sum, clientX_last - clientX_init, "sum of movementX = clientX_init - clientX_last");
                         assert_equals(movementY_sum, clientY_last - clientY_init, "sum of movementY = clientY_init - clientY_last");
                     });
-                    movementX_Y_inside_window_Test.done();
+                    movementX_Y_outside_window_Test.done();
                 break;
             }
         });
@@ -95,6 +98,11 @@
                     movementY_sum = movementY;
                 }
 
+	            movementX_Y_outside_window_Test.step(function() {
+	            	assert_less_than(Math.abs(movementX), 50, "movementX should not have large jumps in value.");
+	            	assert_less_than(Math.abs(movementY), 50, "movementY should not have large jumps in value.");
+	            });
+
                 movementX_sum += movementX;
                 movementY_sum += movementY;
 
@@ -105,6 +113,15 @@
 
                 updateData();
             }
+        });
+
+        document.addEventListener("mouseenter", function (e) {
+            if(click_counter === 1) {
+	            movementX_Y_outside_window_Test.step(function() {
+	            	assert_greater_than(Math.abs(e.clientX-clientX_last) + Math.abs(e.clientY-clientY_last), 
+	            		100, "Test requires mouse to be moved at least 100 pixels outside of window.");
+	            });
+	        }
         });
 
         function updateData() {

--- a/tests/pointerlock_basic-manual.html
+++ b/tests/pointerlock_basic-manual.html
@@ -69,7 +69,7 @@
 
         document.addEventListener("pointerlockchange", function() {
             event_counter ++;
-console.log("pointer lock change " + event_counter);
+            console.log("pointer lock change " + event_counter);
             if(event_counter === 1) {
                 pointerlockchangeIsFiredonRequest = true;
                 runRequestPointerLockTest();

--- a/tests/pointerlock_basic-manual.html
+++ b/tests/pointerlock_basic-manual.html
@@ -69,7 +69,7 @@
 
         document.addEventListener("pointerlockchange", function() {
             event_counter ++;
-
+console.log("pointer lock change " + event_counter);
             if(event_counter === 1) {
                 pointerlockchangeIsFiredonRequest = true;
                 runRequestPointerLockTest();


### PR DESCRIPTION
movementX_Y_basic-manual.html modified:
- Split out the 'out of window' movement to another test to be more precise about
  not only needing movement, but needing the right kind. Upon re-entering 
  movementX/Y needs to be zero
- Simplified a bit, and arranged debug output to be easier to see where numbers
  should match.
- Be more strict about movementX/Y sums matching changes to mouse movement.

movementX_Y_no-jumps-manual.html created 

pointerlock_basic-manual.html console output helps explain failure in Edge.
