### PR TITLE
improve markup language

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,8 +440,8 @@
       <dl>
         <dt><dfn>movementX</dfn></dt>
         <dt><dfn>movementY</dfn></dt>
-      </dl>
 
+        <dd>
       <p>The members <code>movementX</code> and <code>movementY</code> must
       provide the change in position of the pointer, as if the values of
       <code>screenX</code>, <code>screenY</code>, were stored between two subsequent
@@ -493,6 +493,8 @@
       receives a mouse leaving event at the window system API. As an exception
       mouse capture may allow the <a>User agent</a> to continue receiving mouse
       events when the cursor moves outside the window.</p>
+      </dd>
+    </dl>
     </section>
 
     <section data-dfn-for="MouseEventInit">
@@ -512,6 +514,8 @@
       <dl>
         <dt><dfn>movementX</dfn></dt>
         <dt><dfn>movementY</dfn></dt>
+        <dd>The members <code>movementX</code> and <code>movementY</code> are used to initialize respective members
+      of <code>MouseEvent</code>.</dd>
       </dl>
     </section>
 


### PR DESCRIPTION
to fix the [markup errors](https://validator.w3.org/nu/?doc=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttp%253A%252F%252Fw3c.github.io%252Fpointerlock%252Findex.html%253FspecStatus%253DWD%253BshortName%253Dpointerlock) reported by the validator.