### PR TITLE
Treat DocumentOrShadowRoot as an interface mixin

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@
       <h2>Extensions to the <a>DocumentOrShadowRoot</a> Mixin</h2>
 
       <pre class="idl">
-        partial interface DocumentOrShadowRoot {
+        partial interface mixin DocumentOrShadowRoot {
           readonly attribute Element ? pointerLockElement;
         };
       </pre>


### PR DESCRIPTION
Matching https://dom.spec.whatwg.org/#mixin-documentorshadowroot.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/pointerlock/pull/40.html" title="Last updated on Jan 21, 2019, 2:08 PM UTC (c4e92f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/40/9ce3dca...foolip:c4e92f0.html" title="Last updated on Jan 21, 2019, 2:08 PM UTC (c4e92f0)">Diff</a>