### PR TITLE
Editorial: Add a missing ref-name for requestPointerLock method

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
       </pre>
       <dl>
         <dt>
-          <dfn>requestPointerLock()</dfn> method
+          <dfn>requestPointerLock</dfn> method
         </dt>
         <dd>
           <p>
@@ -241,7 +241,7 @@
             gesture</a>, or pointer lock has not previously been entered for
             this document, an event generated as a result of an <a>engagement
             gesture</a> must be received by the document before
-            {{requestPointerLock()}} will succeed.
+            <a>requestPointerLock</a> will succeed.
           </p>
           <aside class="note" data-link-for="Document">
             <p>
@@ -251,7 +251,7 @@
               re-engages directly with the document.
             </p>
             <p>
-              Conversely, if pointer lock is exited via {{exitPointerLock()}}
+              Conversely, if pointer lock is exited via <a>exitPointerLock</a>
               no <a>engagement gesture</a> is required to reenter pointer lock.
               This enables applications that frequently move between
               interaction modes, and ones that may do so based on a timer or
@@ -327,7 +327,7 @@
           </p>
         </dd>
         <dt>
-          <dfn>exitPointerLock()</dfn> method
+          <dfn>exitPointerLock</dfn> method
         </dt>
         <dd>
           <p>

--- a/index.html
+++ b/index.html
@@ -257,10 +257,10 @@
               interaction modes, and ones that may do so based on a timer or
               remote network activity.
             </p>
-            <p>
+            <p data-link-for="Element">
               Pointer lock is commonly combined with fullscreen [[FULLSCREEN]],
               and if an <a>engagement gesture</a> is used to enter fullscreen
-              it is sufficient for a subsequent requestPointerLock.
+              it is sufficient for a subsequent <a>requestPointerLock</a>.
             </p>
           </aside>
           <p>

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
       </pre>
       <dl>
         <dt>
-          <dfn>requestPointerLock</dfn> method
+          <dfn>requestPointerLock()</dfn> method
         </dt>
         <dd>
           <p>
@@ -241,7 +241,7 @@
             gesture</a>, or pointer lock has not previously been entered for
             this document, an event generated as a result of an <a>engagement
             gesture</a> must be received by the document before
-            <a>requestPointerLock</a> will succeed.
+            {{requestPointerLock()}} will succeed.
           </p>
           <aside class="note" data-link-for="Document">
             <p>
@@ -251,7 +251,7 @@
               re-engages directly with the document.
             </p>
             <p>
-              Conversely, if pointer lock is exited via <a>exitPointerLock</a>
+              Conversely, if pointer lock is exited via {{exitPointerLock()}}
               no <a>engagement gesture</a> is required to reenter pointer lock.
               This enables applications that frequently move between
               interaction modes, and ones that may do so based on a timer or
@@ -260,7 +260,7 @@
             <p data-link-for="Element">
               Pointer lock is commonly combined with fullscreen [[FULLSCREEN]],
               and if an <a>engagement gesture</a> is used to enter fullscreen
-              it is sufficient for a subsequent <a>requestPointerLock</a>.
+              it is sufficient for a subsequent {{requestPointerLock()}}.
             </p>
           </aside>
           <p>
@@ -327,7 +327,7 @@
           </p>
         </dd>
         <dt>
-          <dfn>exitPointerLock</dfn> method
+          <dfn>exitPointerLock()</dfn> method
         </dt>
         <dd>
           <p>


### PR DESCRIPTION
Change the ref-name of the functions to make it
easier in the follow up changes to add parameters


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/pull/48.html" title="Last updated on Jul 16, 2019, 1:59 AM UTC (ea68465)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/48/4b84cb8...ea68465.html" title="Last updated on Jul 16, 2019, 1:59 AM UTC (ea68465)">Diff</a>