### PR TITLE
Editorial: Use xref to link document active sandboxing flag set

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,8 +225,7 @@
           </p>
           <p>
             Pointer lock must not succeed if the document object's
-            <a data-cite="html/origin.html#active-sandboxing-flag-set">active
-            sandboxing flag set</a> has the <a>sandboxed pointer lock browsing
+            [=Document/active sandboxing flag set=] has the <a>sandboxed pointer lock browsing
             context flag</a> set.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -225,8 +225,8 @@
           </p>
           <p>
             Pointer lock must not succeed if the document object's
-            [=Document/active sandboxing flag set=] has the <a>sandboxed pointer lock browsing
-            context flag</a> set.
+            [=Document/active sandboxing flag set=] has the <a>sandboxed
+            pointer lock browsing context flag</a> set.
           </p>
           <p>
             Pointer lock must not succeed unless the <a>target</a>'s
@@ -955,7 +955,8 @@
         Acknowledgments
       </h2>
       <p>
-        Many thanks to lots of people who made contributions to the discussions of this specification:
+        Many thanks to lots of people who made contributions to the discussions
+        of this specification:
       </p>
       <ul>
         <li>Adam Barth


### PR DESCRIPTION
Closes #56


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/pointerlock/pull/57.html" title="Last updated on Jan 23, 2020, 2:46 AM UTC (74f615d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/57/1ce79b7...janiceshiu:74f615d.html" title="Last updated on Jan 23, 2020, 2:46 AM UTC (74f615d)">Diff</a>