### PR TITLE
chore: xref uievents

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
     </script>
   </head>
-  <body>
+  <body data-cite="uievents">
     <section id='abstract'>
       This specification defines an API that provides scripted access to raw
       mouse movement data while locking the target of mouse events to a single


### PR DESCRIPTION
@mustaqahmed, this fixes cross-reference errors for `MouseEvent` and related errors.

However, the spec is trying to link to "activation triggering input event", which is not a thing in any spec. 

Can you point me to what you would like the above to link to? Presumedly it's something in the UI events spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/pull/69.html" title="Last updated on Jul 1, 2021, 2:15 AM UTC (6b9205c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/69/8ff26a6...6b9205c.html" title="Last updated on Jul 1, 2021, 2:15 AM UTC (6b9205c)">Diff</a>