### PR TITLE
Use respec conventions for event definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,9 @@
       </h2>
       <p>
         Two events are used to communicate pointer lock state change or an
-        error in changing state. They are named <dfn>pointerlockchange</dfn>
-        and <dfn>pointerlockerror</dfn>. If pointer lock is entered or exited
-        for any reason a <a>pointerlockchange</a> event must be sent.
+        error in changing state. They are named <dfn data-dfn-for="Document" data-dfn-type="event">pointerlockchange</dfn>
+        and <dfn data-dfn-for="Document" data-dfn-type="event">pointerlockerror</dfn>. If pointer lock is entered or exited
+        for any reason a {{Document/pointerlockchange}} event must be sent.
       </p>
       <p>
         <a>User agents</a> must deliver these events by <a data-lt=
@@ -192,7 +192,7 @@
             Requests that the pointer be locked to a DOM element
             <dfn>target</dfn>. The <a>user agent</a> determines if pointer lock
             state will be entered, and upon lock state change or error MUST send
-            either a <a>pointerlockchange</a> or <a>pointerlockerror</a> event
+            either a {{Document/pointerlockchange}} or {{Document/pointerlockerror}} event
             respectively.
           </p>
           <p>
@@ -236,13 +236,13 @@
             If any element (including this one), whose <a>shadow-including
             root</a> is same as this element's <a>shadow-including root</a>, is
             already locked (or pending lock) the pointer lock <a>target</a>
-            must be updated to this element and a <a>pointerlockchange</a>
+            must be updated to this element and a {{Document/pointerlockchange}}
             event sent.
           </p>
           <p>
             If any element, whose <a>shadow-including root</a> is a different
             document, is already locked the request must fail and a
-            <a>pointerlockerror</a> event be sent.
+            {{Document/pointerlockerror}} event be sent.
           </p>
           <p>
             Once in the locked state the <a>user agent</a> must fire all
@@ -282,7 +282,7 @@
         </dt>
         <dd>
           <p>
-            An <a>event handler idl attribute</a> for <a>pointerlockchange</a>
+            An <a>event handler idl attribute</a> for {{Document/pointerlockchange}}
             events.
           </p>
         </dd>
@@ -291,7 +291,7 @@
         </dt>
         <dd>
           <p>
-            An <a>event handler idl attribute</a> for <a>pointerlockerror</a>
+            An <a>event handler idl attribute</a> for {{Document/pointerlockerror}}
             events.
           </p>
         </dd>
@@ -302,7 +302,7 @@
           <p>
             Initiates an exit from pointer lock state if currently locked to a
             target whose <a>shadow-including root</a> is this document, and
-            sends a <a>pointerlockchange</a> event when the lock state has been
+            sends a {{Document/pointerlockchange}} event when the lock state has been
             exited.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       <!-- Status of This Document -->
       <p>
         A history of changes to this document can be found at <a href=
-        "https://github.com/w3c/pointerlock/commits/gh-pages/index.html">http://dvcs.w3.org/hg/pointerlock/log/default/index.html</a>
+        "https://github.com/w3c/pointerlock/commits/gh-pages/index.html">https://github.com/w3c/pointerlock/commits/gh-pages/index.html</a>
       </p>
       <p>
         Summary of changes since <a href=


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/pointerlock/pull/79.html" title="Last updated on Jul 6, 2022, 9:31 AM UTC (61902e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/79/d418556...dontcallmedom:61902e4.html" title="Last updated on Jul 6, 2022, 9:31 AM UTC (61902e4)">Diff</a>