### PR TITLE
Add lock options to requestPointerLock

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>
+        <title>
       Pointer Lock 2.0
     </title>
     <meta charset="utf-8"><!--
@@ -69,7 +69,10 @@
         ],
         github: "w3c/pointerlock",
         group: "webapps",
-        xref: "web-platform"
+        xref: {
+                specs: ["uievents"],
+                profile: "web-platform",
+        },
       };
 
     </script>
@@ -146,126 +149,355 @@
     </section>
     <section>
       <h2>
-        <code>pointerlockchange</code> and <code>pointerlockerror</code> Events
+        Pointer Lock and Interfaces
       </h2>
-      <p>
-        Two events are used to communicate pointer lock state change or an
-        error in changing state. They are named <dfn data-dfn-for="Document"
-        data-dfn-type="event">pointerlockchange</dfn> and <dfn data-dfn-for=
-        "Document" data-dfn-type="event">pointerlockerror</dfn>. If pointer
-        lock is entered or exited for any reason a
-        {{Document/pointerlockchange}} event must be sent.
-      </p>
-      <p>
-        <a>User agents</a> must deliver these events by <a data-lt=
-        "queue a task">queuing a task</a> to <a>fire an event</a> of the
-        appropriate name with its <code>bubbles</code> attribute [[DOM]] set to
-        false to the pointer lock <a>target</a> element's [=Node/node
-        document=].
-      </p>
-      <p class="note">
-        Magnification software increases the size of content on the screen. It
-        uses the mouse to move the magnified point of focus around. When a
-        pointer lock is initiated, the magnification software needs to switch
-        to using the keyboard to move the magnified point of focus around
-        instead. When a pointerlockchange event is fired, web browsers
-        therefore need to make sure the event is communicated to assistive
-        technologies like screen magnifiers.
-      </p>
+      <section>
+        <h3>
+          The <dfn>pointer lock state</dfn> definition
+        </h3>
+        <p>
+          The [=pointer lock state=] is the state where a single DOM element,
+          which we will call the <dfn>pointer-lock target</dfn>, receives all
+          mouse events and the cursor is hidden.
+        </p>
+        <p>
+          Once in the [=pointer lock state=] the [=user agent=] has a
+          [=pointer-lock target=], a <dfn>pointer-lock options</dfn>, which is
+          a {{PointerLockOptions}} and a <dfn>cursor position</dfn> which is a
+          pair of numbers representing the location of the system mouse cursor
+          when the Pointer Lock State was entered (the same location that is
+          reported in `screenX`, `screenY`). The [=pointer-lock target=]
+          receives all relevant user generated {{MouseEvent}} events: namely,
+          all user-generated `mousemove`, `mousedown`, `mouseup`, `click`,
+          `dblclick`, `auxclick`, and `wheel` [[ui-events]]. No other elements
+          receive these events while in [=pointer lock state=]. There will be
+          no dispatching of events that require the concept of a mouse cursor:
+          namely, `mouseenter`, `mouseleave`, `mouseover`, `mouseout`, `drag`,
+          and `drop`.
+          <aside class="issue" data-number="97"></aside>
+        </p>
+        <p>
+          While in the [=pointer lock state=] if the [=pointer-lock options=]'
+          {{PointerLockOptions/unadjustedMovement}} member is `true`, the event
+          coordinates will not be affected by the underlying platform behaviors
+          such as mouse acceleration. In other words, the user agent uses the
+          APIs provided by the underlying platform to guarantee getting the raw
+          events. If the {{PointerLockOptions}}'
+          {{PointerLockOptions/unadjustedMovement}} member is `false`, the user
+          agent relies on the default behavior of the underlying platform
+          regarding the mouse acceleration.
+        </p>
+        <p>
+          In the [=pointer lock state=], the system mouse cursor is hidden and
+          the window is prevented from losing focus, regardless of mouse
+          movement or button presses. This is directly or indirectly achieved
+          utilizing the underlying operating system API.
+        </p>
+        <p class="note">
+          Synthetic mouse events created by application script act the same
+          regardless of lock state.
+        </p>
+      </section>
+      <section data-dfn-for="PointerLockOptions">
+        <h3>
+          `PointerLockOptions` dictionary
+        </h3>
+        <pre class="idl">
+          dictionary PointerLockOptions {
+            boolean unadjustedMovement = false;
+          };
+        </pre>
+        <dl>
+          <dt>
+            <dfn>PointerLockOptions</dfn> dictionary
+          </dt>
+          <dd>
+            <p>
+              The options dictionary to customize how the pointer behaves in
+              the locked mode.
+            </p>
+          </dd>
+          <dt>
+            <dfn>unadjustedMovement</dfn> member
+          </dt>
+          <dd>
+            <p>
+              If this value is set to `true`, then the pointer movements will
+              not be affected by the underlying platform modifications such as
+              mouse accelaration.
+            </p>
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h3>
+          `pointerlockchange` and `pointerlockerror` Events
+        </h3>
+        <p>
+          Two events are used to communicate pointer lock state change or an
+          error in changing state. They are named <dfn class=
+          "event">pointerlockchange</dfn> and <dfn class=
+          "event">pointerlockerror</dfn>. Refer to algorithm of
+          [[[#requestPointerLock]]] for detail.
+        </p>
+        <p class="note">
+          Magnification software increases the size of content on the screen.
+          It uses the mouse to move the magnified point of focus around. When a
+          pointer lock is initiated, the magnification software needs to switch
+          to using the keyboard to move the magnified point of focus around
+          instead. When a {{pointerlockchange}} event is fired, web browsers
+          therefore need to make sure the event is communicated to assistive
+          technologies like screen magnifiers.
+        </p>
+      </section>
+      <section>
+        <h3>
+          <dfn>Exit Pointer Lock</dfn>
+        </h3>
+        <p>
+          The process of exiting pointer lock, given an |element:Element|, is
+          as follows:
+        </p>
+        <ol class="algorithm">
+          <li>The system mouse cursor must be displayed again and positioned at
+          [=cursor position=].
+          </li>
+          <li>[=Queue an element task=] on the [=user interaction task source=]
+          to [=fire an event=] named {{pointerlockchange}} at the given
+          |element:Element|'s [=Node/node document=].
+          </li>
+          <li>Exit the [=pointer lock state=] by setting [=pointer-lock
+          target=], [=pointer-lock options=], and [=cursor position=] to null.
+          </li>
+        </ol>
+      </section>
     </section>
-    <section data-dfn-for="Element" data-link-for="Element">
+    <section data-dfn-for="Element" data-link-for="Element" id=
+    "requestPointerLock">
       <h2>
         Extensions to the `Element` Interface
       </h2>
       <p>
-        The <a>Element</a> interface is extended to provide the ability to
-        request the the pointer be locked.
+        The {{Element}} interface is extended to provide the ability to request
+        the pointer be locked.
       </p>
       <pre class="idl">
         partial interface Element {
-          undefined requestPointerLock();
+          Promise&lt;undefined&gt; requestPointerLock(optional PointerLockOptions options = {});
         };
       </pre>
+      <pre class='example'>
+        const lock_element = document.getElementById("lock_element");
+        const lock_button = document.getElementById("lock");
+        lock_button.addEventListener("click", async (event) =&gt; {
+            try {
+                await lock_element.requestPointerLock({ unadjustedMovement: true });
+                console.log("successfully locked!");
+            } catch (e) {
+                console.log("lock failed with error: ", e);
+            }
+        });
+    </pre>
       <dl>
         <dt>
-          <dfn>requestPointerLock()</dfn> method
+          requestPointerLock({{PointerLockOptions}} options) method
         </dt>
         <dd>
           <p>
-            Requests that the pointer be locked to a DOM element
-            <dfn>target</dfn>. The <a>user agent</a> determines if pointer lock
-            state will be entered, and upon lock state change or error MUST
-            send either a {{Document/pointerlockchange}} or
-            {{Document/pointerlockerror}} event respectively.
+            A [=parallel queue=] named as <dfn>lock requests queue</dfn> is
+            used for queuing all requests. When <dfn>requestPointerLock()</dfn>
+            is invoked, perform the following steps:
           </p>
-          <p>
-            Pointer lock MUST fail if the document object's [=Document/active
-            sandboxing flag set=] has the <a>sandboxed pointer lock browsing
-            context flag</a> set.
-          </p>
-          <p>
-            Pointer lock MUST fail unless the <a>target</a>'s
-            <a>shadow-including root</a> is the [=navigable/active document=]
-            of a [=Document/browsing context=] which is (or has an
-            [=tree/ancestor=] [=Document/browsing context=] which is) in focus
-            by a window which is in focus by the operating system's window
-            manager. The <a>target</a> element and its [=Document/browsing
-            context=] need not be in focus.
-          </p>
-          <p>
-            Pointer lock is a <a>transient activation-gated API</a>, therefore
-            a {{requestPointerLock()}} call MUST fail if the <a>relevant global
-            object</a> of [=this=] does not have <a>transient activation</a>.
-            This prevents locking upon initial navigation or re-acquiring lock
-            without user's attention.
-          </p>
-          <p>
-            A {{requestPointerLock()}} call immediately after the <a>default
-            unlock gesture</a> MUST fail even when <a>transient activation</a>
-            is available, to prevent malicious sites from acquiring an
-            unescapable locked state through repeated lock attempts. On the
-            other hand, a {{requestPointerLock()}} call immediately after a
-            programmatic lock exit (through a {{Document/exitPointerLock()}}
-            call) MUST succeed when <a>transient activation</a> is available,
-            to enable applications to move frequently between interaction
-            modes, possibly through a timer or remote network activity.
-          </p>
+          <ol class="algorithm">
+            <li>Let |promise:Promise| be [=a new promise=].
+            </li>
+            <li>When a {{Window/window}} is in [=Window/focus=], if the
+            [=this=]'s [=shadow-including root=] is the [=navigable/active
+            document=] of a [=Document/browsing context=] (or has an
+            [=tree/ancestor=] [=browsing context=]) that is not in focus:
+              <ol>
+                <li>[=Queue an element task=] on the [=user interaction task
+                source=], given [=this=], to perform the following steps:
+                  <ol>
+                    <li>[=Fire an event=] named {{pointerlockerror}} at
+                    [=this=]'s [=Node/node document=].
+                    </li>
+                    <li>[=Reject=] |promise| with a {{"WrongDocumentError"}}
+                    {{DOMException}}.
+                    </li>
+                  </ol>
+                </li>
+                <li>Return <var>promise</var>.
+                </li>
+              </ol>
+              <aside class="issue" data-number="93"></aside>
+            </li>
+            <li>If the 'relevant global object does not have [=transient
+            activation=] and the {{Document}} has not previously released a
+            successful pointer lock with {{Document/exitPointerLock()}}:
+              <ol>
+                <li>[=Queue an element task=] on the [=user interaction task
+                source=], given [=this=], to perform the following steps:
+                  <ol>
+                    <li>[=Fire an event=] named {{pointerlockerror}} at
+                    [=this=]'s [=Node/node document=].
+                    </li>
+                    <li>[=Reject=] <var>promise</var> with a
+                    "{{NotAllowedError}}" {{DOMException}}.
+                    </li>
+                  </ol>
+                </li>
+                <li>Return <var>promise</var>.
+                </li>
+              </ol>
+              <aside class="note">
+                When a single <a>user activation</a> initiates both pointer
+                lock and fullscreen [[FULLSCREEN]], the
+                {{requestPointerLock()}} call succeeds only when it is made
+                before a fullscreen request because fullscreen is a
+                <a>transient activation-consuming API</a>.
+              </aside>
+            </li>
+            <li>If [=this=]'s [=Node/node document=]'s [=Document/active
+            sandboxing flag set=] has the [=sandboxed pointer lock browsing
+            context flag=] set:
+              <ol>
+                <li>[=Queue an element task=] on the [=user interaction task
+                source=], given [=this=], to perform the following steps:
+                  <ol>
+                    <li>[=Fire an event=] named {{pointerlockerror}} at
+                    [=this=]'s [=Node/node document=].
+                    </li>
+                    <li>[=Reject=] <var>promise</var> with a
+                    "{{SecurityError}}" {{DOMException}}.
+                    </li>
+                  </ol>
+                </li>
+                <li>Return <var>promise</var>.
+                </li>
+              </ol>
+            </li>
+            <li>If options["{{PointerLockOptions/unadjustedMovement}}"] is true
+            and the platform does not support
+            {{PointerLockOptions/unadjustedMovement}}:
+              <ol>
+                <li>[=Queue an element task=] on the [=user interaction task
+                source=], given [=this=], to perform the following steps:
+                  <ol>
+                    <li>[=Fire an event=] named {{pointerlockerror}} at
+                    [=this=]'s [=Node/node document=].
+                    </li>
+                    <li>[=Reject=] <var>promise</var> with a
+                    "{{NotSupportedError}}" {{DOMException}}.
+                    </li>
+                  </ol>
+                </li>
+                <li>Return <var>promise</var>.
+                </li>
+              </ol>
+              <aside class="issue" data-number="90"></aside>
+            </li>
+            <li>Enqueue the following steps to the [=lock requests queue=]:
+              <ol>
+                <li>If the user agent's [=pointer-lock target=] is an element
+                whose [=shadow-including root=] is not equal to [=this=]'s
+                [=shadow-including root=], then:
+                  <ol>
+                    <li>[=Queue an element task=] on the [=user interaction
+                    task source=], given [=this=], to perform the following
+                    steps:
+                      <ol>
+                        <li>[=Fire an event=] named {{pointerlockerror}} at
+                        [=this=]'s [=Node/node document=].
+                        </li>
+                        <li>[=Reject=] <var>promise</var> with a
+                        "{{InvalidStateError}}" {{DOMException}}.
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li>If the user agent's [=pointer-lock target=]'s
+                [=shadow-including root=] is equal to [=this=]'s
+                [=shadow-including root=] and options are equivalent to the
+                current [=pointer-lock options=], then:
+                  <ol>
+                    <li>Set [=pointer-lock target=] to [=this=].
+                    </li>
+                    <li>[=Queue an element task=] on the [=user interaction
+                    task source=], given [=this=], to perform the following
+                    steps:
+                      <ol>
+                        <li>[=Fire an event=] named {{pointerlockchange}} at
+                        [=this=]'s [=Node/node document=].
+                        </li>
+                        <li>[=Resolve=] the <var>promise</var>.
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li>If [=pointer-lock target=] is null, or options is not
+                equivalent to the current [=pointer-lock options=], process the
+                lock request and handle response upon fulfillment:
+                  <ol>
+                    <li>If the lock request failed:
+                      <ol>
+                        <li>[=Queue an element task=] on the [=user interaction
+                        task source=], given [=this=], to perform the following
+                        steps:
+                          <ol>
+                            <li>[=Fire an event=] named {{pointerlockerror}} at
+                            [=this=]'s [=Node/node document=].
+                            </li>
+                            <li>[=Reject=] <var>promise</var> with a
+                            "{{NotSupportedError}}" {{DOMException}}.
+                            </li>
+                          </ol>
+                        </li>
+                      </ol>
+                      <aside class="issue" data-number="91"></aside>
+                    </li>
+                    <li>If the lock request succeed:
+                      <ol>
+                        <li>Enter [=pointer lock state=] by performing the
+                        following:
+                          <ol>
+                            <li>Set the user agent's [=pointer-lock target=] to
+                            [=this=].
+                            </li>
+                            <li>Set the user agent's [=cursor position=] to the
+                            current system mouse location.
+                            </li>
+                            <li>Set the [=pointer-lock options=] to options.
+                            </li>
+                          </ol>
+                        </li>
+                        <li>[=Queue an element task=] on the [=user interaction
+                        task source=], given [=this=], to perform the following
+                        steps:
+                          <ol>
+                            <li>[=Fire an event=] named {{pointerlockchange}}
+                            at [=this=]'s [=Node/node document=].
+                            </li>
+                            <li>[=Resolve=] the <var>promise</var>.
+                            </li>
+                          </ol>
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+              <aside class="issue" data-number="96"></aside>
+            </li>
+            <li>Return <var>promise</var>.
+            </li>
+          </ol>
           <aside class="note">
-            When a single <a>user activation</a> initiates both pointer lock
-            and fullscreen [[FULLSCREEN]], the {{requestPointerLock()}} call
-            succeeds only when it is made before a fullscreen request because
-            fullscreen is a <a>transient activation-consuming API</a>.
+            This algorithm is under active development and may be modified in
+            subsequent updates.
           </aside>
-          <p>
-            If any element (including this one), whose <a>shadow-including
-            root</a> is same as this element's <a>shadow-including root</a>, is
-            already locked (or pending lock) the pointer lock <a>target</a>
-            must be updated to this element and a
-            {{Document/pointerlockchange}} event sent.
-          </p>
-          <p>
-            If any element, whose <a>shadow-including root</a> is a different
-            document, is already locked the request must fail and a
-            {{Document/pointerlockerror}} event be sent.
-          </p>
-          <p>
-            Once in the locked state the <a>user agent</a> must fire all
-            relevant user generated {{MouseEvent}} events (for example:
-            `mousemove`, `mousedown`, `mouseup`, `click`, and `wheel`)
-            [[ui-events]] to the <a>target</a> of pointer lock, and not fire
-            mouse events to other elements. Events that require the concept of
-            a mouse cursor must not be dispatched (for example: `mouseover`,
-            `mouseout`, `drag`, and `drop`).
-          </p>
-          <p>
-            In the locked state the system mouse cursor must be hidden.
-            Movement and button presses of the mouse must not cause the window
-            to lose focus.
-          </p>
-          <p>
-            Synthetic mouse events created by application script act the same
-            regardless of lock state.
-          </p>
         </dd>
       </dl>
     </section>
@@ -286,7 +518,7 @@
         </dt>
         <dd>
           <p>
-            An <a>event handler idl attribute</a> for
+            An [=event handler idl attribute=] for
             {{Document/pointerlockchange}} events.
           </p>
         </dd>
@@ -295,7 +527,7 @@
         </dt>
         <dd>
           <p>
-            An <a>event handler idl attribute</a> for
+            An [=event handler idl attribute=] for
             {{Document/pointerlockerror}} events.
           </p>
         </dd>
@@ -303,18 +535,16 @@
           <dfn>exitPointerLock()</dfn> method
         </dt>
         <dd>
-          <p>
-            Initiates an exit from pointer lock state if currently locked to a
-            target whose <a>shadow-including root</a> is this document, and
-            sends a {{Document/pointerlockchange}} event when the lock state
-            has been exited.
-          </p>
-          <p>
-            The system mouse cursor must be displayed again and positioned at
-            the same location that it was when pointer lock was entered (the
-            same location that is reported in <code>screenX</code>,
-            <code>screenY</code>, when the pointer is locked).
-          </p>
+          <ol>
+            <li>If the user agent's pointer-lock target is null, then return.
+            </li>
+            <li>If [=pointer-lock target=]'s [=shadow-including root=]is not
+            equal to [=this=]'s [=Node/node document=], return.
+            </li>
+            <li>[=Exit pointer lock=] with the user agent's [=pointer-lock
+            target=].
+            </li>
+          </ol>
         </dd>
       </dl>
     </section>
@@ -324,7 +554,7 @@
       </h2>
       <pre class="idl">
         partial interface mixin DocumentOrShadowRoot {
-          readonly attribute Element ? pointerLockElement;
+          readonly attribute Element? pointerLockElement;
         };
       </pre>
       <dl>
@@ -333,10 +563,10 @@
         </dt>
         <dd>
           <p>
-            While the pointer is locked, returns the result of
-            <a>retargeting</a> the element, which is the target for mouse
-            events, against [=this=] element if the result and [=this=] element
-            are in the same tree, otherwise returns null.
+            While the pointer is locked, returns the result of [=retargeting=]
+            the element, which is the target for mouse events, against [=this=]
+            element if the result and [=this=] element are in the same tree,
+            otherwise returns null.
           </p>
           <p>
             Returns null if lock is pending or if pointer is unlocked.
@@ -355,19 +585,16 @@
                 &lt;/div&gt;
               &lt;/body&gt;
           </pre>
-          <p>
-            Note: the example uses fictional <code>shadow-root</code> element
-            to denote a [=Element/shadow root=] instance.
+          <p class="note">
+            The example uses fictional `shadow-root` element to denote a
+            [=Element/shadow root=] instance.
           </p>
           <p>
-            If <code>#canvas1</code> is the target,
-            <code>document.pointerLockElement</code> returns
-            <code>#host1</code>, and <code>root1.pointerLockElement</code>
-            returns <code>#canvas1</code>. The result of <a>retargeting</a>
-            <code>#canvas1</code> against <code>#root2</code> is
-            <code>#host1</code>, but as <code>#host1</code> is not in the same
-            tree as <code>#root2</code>, null will be returned for
-            <code>root2.pointerLockElement</code>.
+            If `#canvas1` is the target, `document.pointerLockElement` returns
+            `#host1`, and `root1.pointerLockElement` returns `#canvas1`. The
+            result of [=retargeting=] `#canvas1` against `#root2` is `#host1`,
+            but as `#host1` is not in the same tree as `#root2`, null will be
+            returned for `root2.pointerLockElement`.
           </p>
         </dd>
       </dl>
@@ -392,63 +619,60 @@
         </dt>
         <dd>
           <p>
-            The attributes {{movementX}} {{movementY}} must provide the change
-            in position of the pointer, as if the values of
-            <code>screenX</code>, <code>screenY</code>, were stored between two
-            subsequent <code>mousemove</code> events <code>eNow</code> and
-            <code>ePrevious</code> and the difference taken <code>movementX =
-            eNow.screenX-ePrevious.screenX</code>.
+            The attributes {{movementX}} and {{movementY}} must provide the
+            change in position of the pointer, as if the values of `screenX`,
+            `screenY`, were stored between two subsequent `mousemove` events
+            `eNow` and `ePrevious` and the difference taken `movementX =
+            eNow.screenX - ePrevious.screenX`.
           </p>
           <p>
-            {{movementX}}/{{movementY}} must be zero for all mouse events
-            except <code>mousemove</code>. All motion data must be delivered
-            via <code>mousemove</code> events such that between any two mouse
-            events <code>earlierEvent</code> and <code>currentEvent</code> the
-            value of <code>currentEvent.screenX-earlierEvent.screenX</code> is
-            equivalent to the sum of all {{movementX}} {{movementY}}/code&gt;
-            events after <code>earlierEvent</code>, with the exception of when
-            screenX can not be updated because the pointer is clipped by the
-            <a>user agent</a> screen boundaries.
+            {{movementX}} and {{movementY}} must be zero for all mouse events
+            except `mousemove`. All motion data must be delivered via
+            `mousemove` events such that between any two mouse events
+            `earlierEvent` and `currentEvent` the value of
+            `currentEvent.screenX - earlierEvent.screenX` is equivalent to the
+            sum of all {{movementX}} in the events after `earlierEvent`, with
+            the exception of when screenX can not be updated because the
+            pointer is clipped by the [=user agent=] screen boundaries.
           </p>
           <p>
-            {{movementX}}/{{movementY}} must be updated regardless of pointer
-            lock state.
+            {{movementX}} and {{movementY}} must be updated regardless of
+            pointer lock state.
           </p>
           <p>
-            When unlocked, the system cursor can exit and re-enter the <a>user
-            agent</a> window. If it does so and the <a>user agent</a> was not
-            the target of operating system mouse move events then the most
-            recent pointer position will be unknown to the <a>user agent</a>
-            and {{movementX}}/{{movementY}} can not be computed and must be set
+            When unlocked, the system cursor can exit and re-enter the [=user
+            agent=] window. If it does so and the [=user agent=] was not the
+            target of operating system mouse move events then the most recent
+            pointer position will be unknown to the [=user agent=] and
+            {{movementX}} / {{movementY}} can not be computed and must be set
             to zero.
           </p>
           <p>
-            When pointer lock is enabled <code>clientX</code>,
-            <code>clientY</code>, <code>screenX</code>, and
-            <code>screenY</code> must hold constant values as if the pointer
-            did not move at all once pointer lock was entered. But
-            {{movementX}}/{{movementY}} must continue to provide the change in
-            position of the pointer as when the pointer is unlocked. There will
-            be no limit to {{movementX}}/{{movementY}} values if the mouse is
+            When pointer lock is enabled `clientX`, `clientY`, `screenX`, and
+            `screenY` must hold constant values as if the pointer did not move
+            at all once pointer lock was entered. But {{movementX}} and
+            {{movementY}} must continue to provide the change in position of
+            the pointer as when the pointer is unlocked. There will be no limit
+            to {{movementX}} and {{movementY}} values if the mouse is
             continuously moved in a single direction. The concept of the mouse
             cursor will have been removed, and it will not move off the window
             or be clamped by a screen edge.
           </p>
           <p>
-            The un-initialized value of {{movementX}}/{{movementY}} must be
-            <code>0</code>.
+            The un-initialized value of {{movementX}} and {{movementY}} must be
+            `0`.
           </p>
           <p>
             Large movement values must not appear in situations when mouse
             input is interupted, such as the mouse cursor leaving the window
-            and then re-entering at another location. If a <a>User agent</a>
+            and then re-entering at another location. If a [=user agent=]
             experiences a gap in receiving mouse input data from the operating
-            system then the next generated <code>mousemove</code> event must
-            have {{movementX}}/{{movementY}} set to <code>0</code>. These gaps
-            may appear for example when the <a>User agent</a> receives a mouse
-            leaving event at the window system API. As an exception mouse
-            capture may allow the <a>User agent</a> to continue receiving mouse
-            events when the cursor moves outside the window.
+            system then the next generated `mousemove` event must have
+            {{movementX}} and {{movementY}} set to `0`. These gaps may appear
+            for example when the [=user agent=] receives a mouse leaving event
+            at the window system API. As an exception mouse capture may allow
+            the [=user agent=] to continue receiving mouse events when the
+            cursor moves outside the window.
           </p>
         </dd>
       </dl>
@@ -483,29 +707,30 @@
       </h2>
       <p>
         A <dfn>default unlock gesture</dfn> must always be available that will
-        exit pointer lock.
+        [=exit pointer lock=] with the [=user agent=]'s [=pointer-lock
+        target=].
       </p>
       <aside class="note">
         <p>
-          The ESC key is the recommended <a>default unlock gesture</a> for
-          <a>user agents</a> with keyboard input. It is recommended that the
-          unlock gesture also match any used to exit fullscreen [[FULLSCREEN]].
+          The ESC key is the recommended [=default unlock gesture=] for [=user
+          agents=] with keyboard input. It is recommended that the unlock
+          gesture also match any used to exit fullscreen [[FULLSCREEN]].
         </p>
       </aside>
       <p>
-        Pointer lock must be exited if the <a>target</a> <a data-lt=
-        "become disconnected">becomes disconnected</a>, or the <a>user
-        agent</a>, window, or tab loses focus. Moving focus between elements of
+        Pointer lock must be exited if the [=pointer-lock target=] <a data-lt=
+        "become disconnected">becomes disconnected</a>, or the [=user agent=],
+        window, or tab loses focus. Moving focus between elements of
         [=navigable/active document=], including between [=Document/browsing
-        contexts=] , does not exit pointer lock. E.g. using the keyboard to
+        contexts=] , does not [=exit pointer lock=]. E.g. using the keyboard to
         move focus between contents of frames or iframes will not exit.
       </p>
       <p>
         Pointer lock must not be exited when fullscreen [[FULLSCREEN]] is
         entered or exited unless the pointer is required to enable interaction
-        with the <a>user agent</a> graphical user interface, the <a>default
-        unlock gesture</a> was used to exit both fullscreen and pointer lock,
-        or window or tab focus was lost.
+        with the [=user agent=] graphical user interface, the [=default unlock
+        gesture=] was used to exit both fullscreen and pointer lock, or window
+        or tab focus was lost.
       </p>
     </section>
     <section class='informative'>
@@ -588,7 +813,7 @@
           interact with DOM. E.g. the following code should permit a custom
           cursor to send click events while the pointer is locked:
         </p>
-        <pre class='example' id="example-synthetic-cursor">
+        <pre class='example'>
             document.addEventListener("click", function (e) {
               if (e._isSynthetic)
                 return;
@@ -608,10 +833,10 @@
             });
         </pre>
         <p>
-          Note that synthetic clicks may not be permitted by a <a>user
-          agent</a> to produce the same default action as a non-synthetic
-          click. However, application handlers can still take action and
-          provide user interface with existing HTML & DOM mechanisms.
+          Note that synthetic clicks may not be permitted by a [=user agent=]
+          to produce the same default action as a non-synthetic click. However,
+          application handlers can still take action and provide user interface
+          with existing HTML & DOM mechanisms.
         </p>
       </section>
       <section>
@@ -639,9 +864,9 @@
           Games that use pointer lock may desire a traditional UI and system
           cursor while players prepare in a game lobby. Games usually start
           after a short timer when all players are ready. Ideally the game
-          could then switch to pointer lock mode without a <a>user
-          activation</a>. Players should be able to seamlessly move from the
-          game lobby into game navigation.
+          could then switch to pointer lock mode without a [=user activation=].
+          Players should be able to seamlessly move from the game lobby into
+          game navigation.
         </p>
       </section>
       <section>
@@ -667,50 +892,50 @@
         <li>User actions may be misdirected to elements the user did not intend
         to interact with.
         </li>
-        <li>Pointer Lock will remove the ability of a user to interact with <a>
-          user agent</a> and operating system controls
+        <li>Pointer Lock will remove the ability of a user to interact with [=
+        user agent=] and operating system controls
         </li>
         <li>Pointer Lock can be called repeated by script after user exits
         pointer lock, blocking user from meaningful progress.
         </li>
-        <li>Full screen exit instructions are displayed in some <a>user
-        agent</a>s when the pointer is moved to the top of the screen. During
-        pointer lock that gesture is not possible.
+        <li>Full screen exit instructions are displayed in some [=user agent=]s
+        when the pointer is moved to the top of the screen. During pointer lock
+        that gesture is not possible.
         </li>
       </ul>
       <p>
         Responses:
       </p>
       <ul>
-        <li>
-          <a>User agents</a> may limit what security origins may lock the
-          pointer.
+        <li>The [=user agents=] may limit what security origins may lock the
+        pointer.
         </li>
-        <li>
-          <a>User agents</a> may prompt for confirmation before locking, this
-          preference may be saved as a content setting.
+        <li>The [=user agents=] may prompt for confirmation before locking,
+        this preference may be saved as a content setting.
         </li>
-        <li>Escape will always be provided by a <a>default unlock gesture</a>,
+        <li>Escape will always be provided by a [=default unlock gesture=],
         e.g. Esc key.
         </li>
         <li>Persistent display of escape instructions can be provided.
         </li>
-        <li>Repeated escapes of pointer lock can signal <a>user agent</a> to
-        not re-lock the pointer without more specific user action, e.g. similar
-        to how Chrome suppresses repeated alert() calls.
+        <li>Repeated escapes of pointer lock can signal [=user agent=] to not
+        re-lock the pointer without more specific user action, e.g. similar to
+        how Chrome suppresses repeated alert() calls.
         </li>
         <li>Changing to new tabs, windows, or any other action that causes a
-        page to lose focus will exit pointer lock.
+        page to lose focus will [=exit pointer lock=] with the [=user agent=]'s
+        [=pointer-lock target=].
         </li>
         <li>Pointer lock can only be engaged when the window is in focus in the
-        <a>user agent</a> and operating system.
+        [=user agent=] and operating system.
         </li>
       </ul>
       <p>
         Recommendations:
       </p>
       <ul>
-        <li>Esc key should exit pointer lock.
+        <li>Esc key should [=exit pointer lock=] with the user agent's
+        [=pointer-lock target=].
         </li>
         <li>Preferences per sub-domain can be used to allow or block pointer
         lock, similar to pop-up, geolocation, and fullscreen.
@@ -720,12 +945,12 @@
         Pointer lock is a required user interaction mode for certain
         application types, but carries a usability concern if maliciously used.
         An attacker could remove the ability for a user to control their mouse
-        cursor on their system. <a>User agents</a> will prevent this by always
-        providing a mechanism to exit pointer lock, by informing the user of
-        how, and by limiting how pointer lock can be entered.
+        cursor on their system. [=user agents=] will prevent this by always
+        providing a mechanism to [=exit pointer lock=], by informing the user
+        of how, and by limiting how pointer lock can be entered.
       </p>
       <p>
-        <a>User agents</a> will determine their own appropriate policies, which
+        [=user agents=] will determine their own appropriate policies, which
         may be specialized per device or differ based on user options.
       </p>
     </section>
@@ -779,8 +1004,8 @@
         </h2>
         <p>
           When the pointer is locked 'wheel' events should be sent to the
-          pointer lock <a>target</a> element just as 'mousemove' events are.
-          There is a naming conflict with .deltaX/Y/Z as defined in <a href=
+          [=pointer-lock target=] element just as 'mousemove' events are. There
+          is a naming conflict with .deltaX/Y/Z as defined in <a href=
           "https://w3c.github.io/uievents/#events-wheelevents">DOM 3 'wheel'
           event</a>.
         </p>
@@ -814,10 +1039,10 @@
           movement data are provided in. This specification defines
           .movementX/Y precisely as the same values that could be recorded when
           the mouse is not under lock by changes in .screenX/Y. Implementations
-          across multiple <a>user agents</a> and operating systems will easily
-          be able to meet that requirement and provide application developers
-          and users with a consistent experience. Further, users are expected
-          to have already configured the full system of hardware input and
+          across multiple [=user agents=] and operating systems will easily be
+          able to meet that requirement and provide application developers and
+          users with a consistent experience. Further, users are expected to
+          have already configured the full system of hardware input and
           operating system options resulting in a comfortable control the
           system mouse cursor. By specifying .movementX/Y in the same units
           mouse lock API applications will be instantly usable to all users


### PR DESCRIPTION
This PR replaces #49 originally started by @NavidZ.

The goal of this change is to allow application to access unadjusted mouse movement data while in Pointer Lock. This is a highly requested feature from partners in the gaming space. This change adds a PointerLockOptions object as a parameter to the requestPointerLock() method. The PointerLockOptions object currently only has one useful member which is the boolean unadjustedMovement. Also, to properly return error information and make it easier for developers to implement the requestPointerLock method was changed to return a promise.

The existing Pointer Lock API returns the mouse movement that the platforms give Chrome. By default all platforms include some form of mouse acceleration in the movement information they give Chrome. Mouse acceleration is the artificial increase of velocity when the mouse is moving fast. This is useful in normal use of the pointer when a user is trying to move the mouse across the screen. However, it also makes aiming in first person perspective games very difficult. To solve this problem we are adding an option to get that unadjusted movement data when requesting pointer lock.

With Pointer Lock options now available, applications need the ability to change those options while keeping the lock. This proves difficult using the previous API which fired changed or error events on the document to indicate the result of the request. Particularly troublesome was that the error event gave no reason. To solve this problem for developers a Promise workflow is being introduced. Now when requesting a change the developers can get actionable error information on rejected requests.

Example:
```JS
try {
  await element.requestPointerLock({ unadjustedMovement: true });
  console.log(“pointer lock acquired”);
} catch (error) {
  console.log(`Failed to acquire pointer lock due to ${error}`);
}
```
Closes #36 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [x] WebKit  https://github.com/WebKit/WebKit/pull/17525
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=982379)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/pull/99.html" title="Last updated on Jun 6, 2024, 1:55 PM UTC (29297ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/99/4642646...29297ed.html" title="Last updated on Jun 6, 2024, 1:55 PM UTC (29297ed)">Diff</a>