### PR TITLE
Include `pointermove` when talking about `movementX/Y`

### DIFF
--- a/index.html
+++ b/index.html
@@ -627,9 +627,9 @@
           </p>
           <p>
             {{movementX}} and {{movementY}} must be zero for all mouse events
-            except `mousemove`. All motion data must be delivered via
-            `mousemove` events such that between any two mouse events
-            `earlierEvent` and `currentEvent` the value of
+            except `mousemove` and `pointermove`. All motion data must be
+            delivered via `mousemove` events such that between any two mouse
+            events `earlierEvent` and `currentEvent` the value of
             `currentEvent.screenX - earlierEvent.screenX` is equivalent to the
             sum of all {{movementX}} in the events after `earlierEvent`, with
             the exception of when screenX can not be updated because the


### PR DESCRIPTION
There are three more mention in this part of `mousemove`, should I change them to "`mousemove` and `pointermove`" on every occasion here? I feel like there should be a better solution here.

Fixes #100.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daxpedda/pointerlock/pull/101.html" title="Last updated on Jul 7, 2024, 4:22 PM UTC (01afb68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerlock/101/0e99fcf...daxpedda:01afb68.html" title="Last updated on Jul 7, 2024, 4:22 PM UTC (01afb68)">Diff</a>